### PR TITLE
Import brotli using module path.

### DIFF
--- a/brotli_asgi/__init__.py
+++ b/brotli_asgi/__init__.py
@@ -5,17 +5,20 @@ Code is based on GZipMiddleware shipped with starlette.
 
 import io
 
-from brotli import MODE_FONT, MODE_GENERIC, MODE_TEXT, Compressor  # type: ignore
 from starlette.datastructures import Headers, MutableHeaders
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from ._import_resolver import import_brotli
+
+brotli = import_brotli()
 
 
 class Mode:
     """Brotli available modes."""
 
-    generic = MODE_GENERIC
-    text = MODE_TEXT
-    font = MODE_FONT
+    generic = brotli.MODE_GENERIC
+    text = brotli.MODE_TEXT
+    font = brotli.MODE_FONT
 
 
 class BrotliMiddleware:
@@ -91,7 +94,7 @@ class BrotliResponder:
         self.send = unattached_send  # type: Send
         self.initial_message = {}  # type: Message
         self.started = False
-        self.br_file = Compressor(
+        self.br_file = brotli.Compressor(
             quality=self.quality, mode=self.mode, lgwin=self.lgwin, lgblock=self.lgblock
         )
         self.br_buffer = io.BytesIO()

--- a/brotli_asgi/_import_resolver.py
+++ b/brotli_asgi/_import_resolver.py
@@ -1,0 +1,27 @@
+"""Small utility to solve import conflicts."""
+
+import importlib.util
+from pathlib import Path
+
+import starlette
+
+
+def import_brotli():
+    """Import official google brotli by path.
+
+    If Brotlipy and Brotli (official version) are installed in the same environment it
+    will create a import conflict.
+
+    https://github.com/python-hyper/brotlipy/issues/145
+    """
+    pkg_folder = Path(starlette.__path__[0]).parent
+    brotlipy_folder = pkg_folder / "brotli"
+
+    if brotlipy_folder.exists():
+        google_brotli = pkg_folder / "brotli.py"
+        spec = importlib.util.spec_from_file_location("brotli", google_brotli)
+        brotli = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(brotli)
+    else:
+        import brotli
+    return brotli


### PR DESCRIPTION
Avoids name collision if brotlipy is installed in same environment.
https://github.com/python-hyper/brotlipy/issues/145