### PR TITLE
Fix bug where an incorrect method was called

### DIFF
--- a/brotli_asgi/__init__.py
+++ b/brotli_asgi/__init__.py
@@ -122,7 +122,7 @@ class BrotliResponder:
                 await self.send(message)
             elif not more_body:
                 # Standard Brotli response.
-                body = self.br_file.process(body) + self.br_file.finish()
+                body = self.br_file.compress(body) + self.br_file.finish()
                 headers = MutableHeaders(raw=self.initial_message["headers"])
                 headers["Content-Encoding"] = "br"
                 headers["Content-Length"] = str(len(body))
@@ -136,7 +136,7 @@ class BrotliResponder:
                 headers["Content-Encoding"] = "br"
                 headers.add_vary_header("Accept-Encoding")
                 del headers["Content-Length"]
-                self.br_buffer.write(self.br_file.process(body) + self.br_file.flush())
+                self.br_buffer.write(self.br_file.compress(body) + self.br_file.flush())
 
                 message["body"] = self.br_buffer.getvalue()
                 self.br_buffer.seek(0)
@@ -148,7 +148,7 @@ class BrotliResponder:
             # Remaining body in streaming Brotli response.
             body = message.get("body", b"")
             more_body = message.get("more_body", False)
-            self.br_buffer.write(self.br_file.process(body) + self.br_file.flush())
+            self.br_buffer.write(self.br_file.compress(body) + self.br_file.flush())
             if not more_body:
                 self.br_buffer.write(self.br_file.finish())
                 message["body"] = self.br_buffer.getvalue()


### PR DESCRIPTION
First of all, I want to say great work on this package!

I am running brotli-asgi 0.4 and brotlipy 0.7.0 with Python 3.8.

When I run FastAPI with BrotliMiddleWare, every FileResponse gives this error:

```python
AttributeError: 'Compressor' object has no attribute 'process'  
# ... (truncated traceback logs)
# File ... in send_with_brotli
  self.br_buffer.write(self.br_file.process(body) + self.br_file.flush())
```
Upon some investigation, `self.br_file` is a brotlipy Compressor object: 
```python
self.br_file = Compressor(...)
```

Brotlipy's "Compress" object does not have the method "process". Thus simply switching out "process" with the correct ["compress" method](https://python-hyper.org/projects/brotlipy/en/latest/api.html#compression) fixes the errors and FastAPI can now respond with files properly.