### PR TITLE
Workaround to support both brotli and brotlipy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        brotli-package: [brotli==1.0.7, brotlipy==0.7.0]
+        extras-install: [test_brotli, test_brotlipy]
         python-version: [3.6, 3.7, 3.8]
 
     steps:
@@ -29,11 +29,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest
-
-        pip install ${{ matrix.brotli-package }}
-        pip install starlette==0.13.4
-        pip install requests==2.23.0
-        pip install mypy==0.770
+        pip install '.[${{ matrix.extras-install }}]'
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        brotli-package: [brotli==1.0.7, brotlipy==0.7.0]
         python-version: [3.6, 3.7, 3.8]
 
     steps:
@@ -28,7 +29,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+        pip install ${{ matrix.brotli-package }}
+        pip install starlette==0.13.4
+        pip install requests==2.23.0
+        pip install mypy==0.770
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/brotli_asgi/__init__.py
+++ b/brotli_asgi/__init__.py
@@ -119,7 +119,7 @@ class BrotliResponder:
                 await self.send(message)
             elif not more_body:
                 # Standard Brotli response.
-                body = self.br_file.process(body) + self.br_file.finish()
+                body = self.br_file.compress(body) + self.br_file.finish()
                 headers = MutableHeaders(raw=self.initial_message["headers"])
                 headers["Content-Encoding"] = "br"
                 headers["Content-Length"] = str(len(body))
@@ -133,7 +133,7 @@ class BrotliResponder:
                 headers["Content-Encoding"] = "br"
                 headers.add_vary_header("Accept-Encoding")
                 del headers["Content-Length"]
-                self.br_buffer.write(self.br_file.process(body) + self.br_file.flush())
+                self.br_buffer.write(self.br_file.compress(body) + self.br_file.flush())
 
                 message["body"] = self.br_buffer.getvalue()
                 self.br_buffer.seek(0)
@@ -145,7 +145,7 @@ class BrotliResponder:
             # Remaining body in streaming Brotli response.
             body = message.get("body", b"")
             more_body = message.get("more_body", False)
-            self.br_buffer.write(self.br_file.process(body) + self.br_file.flush())
+            self.br_buffer.write(self.br_file.compress(body) + self.br_file.flush())
             if not more_body:
                 self.br_buffer.write(self.br_file.finish())
                 message["body"] = self.br_buffer.getvalue()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-starlette==0.13.4
-brotli==1.0.7
-# for testing
-requests==2.23.0
-mypy==0.770

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,11 @@ GZipMiddleware for Starlette or FastAPI.
 
 from setuptools import setup  # type: ignore
 
+extras = {
+    'test_brotli': ['requests==2.23.0', 'mypy==0.770'],
+    'test_brotlipy': ['requests==2.23.0', 'mypy==0.770', 'brotlipy==0.7.0']
+}
+
 setup(
     name="brotli-asgi",
     version="0.4",
@@ -19,6 +24,7 @@ setup(
     python_requires=">=3.6",
     include_package_data=True,
     install_requires=["starlette>=0.13.4", "brotli>=1.0.7"],
+    extras_require=extras,
     platforms="any",
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
Closes #10, replaces #6

~~At least on brotli version 1.0.7 (which is what you have pinned in requirements.txt), the `brotli.Compressor.process` attribute doesn't exist, but `brotli.Compressor.compress` does. With this change, tests pass for me locally.~~

I was checking `pip show brotli` to find the version, but I didn't realize I had `brotlipy` also installed, and `brotlipy` clobbers the pure `brotli` import.

The good thing is that the `brotli` and `brotlipy` APIs are nearly identical, just with a difference of `Compressor.compress` and `Compressor.process`. This PR provides a small workaround to call `Compressor.process` if it exists, otherwise fall back to `Compressor.compress`. It also adds tests to run on the latest version of `brotlipy` (but leaves the Google brotli version as the dependency).