### PR TITLE
Feature: Allow excluding handlers from being compressed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.venv
 venv
 __pycache__
 dist

--- a/README.md
+++ b/README.md
@@ -100,4 +100,4 @@ sys.getsizeof(gzip.compress(page, compresslevel=6))
 
 ## Compatibility
 
-According to [caniuse.com](https://caniuse.com/#feat=brotli), Brotli is supported by all major browsers with a global use of over _95%_.
+According to [caniuse.com](https://caniuse.com/#feat=brotli), Brotli is supported by all major browsers with a global use of over _96.3%_.

--- a/brotli_asgi/__init__.py
+++ b/brotli_asgi/__init__.py
@@ -51,6 +51,7 @@ class BrotliMiddleware:
             quality.
         minimum_size: Only compress responses that are bigger than this value in bytes.
         gzip_fallback: If True, uses gzip encoding if br is not in the Accept-Encoding header.
+        excluded_handlers: List of handlers to be excluded from being compressed.
         """
         self.app = app
         self.quality = quality

--- a/brotli_asgi/__init__.py
+++ b/brotli_asgi/__init__.py
@@ -5,7 +5,7 @@ Code is based on GZipMiddleware shipped with starlette.
 
 import io
 import re
-from typing import List, Union
+from typing import List, Union, NoReturn
 
 from brotli import MODE_FONT, MODE_GENERIC, MODE_TEXT, Compressor  # type: ignore
 from starlette.datastructures import Headers, MutableHeaders
@@ -34,7 +34,7 @@ class BrotliMiddleware:
         minimum_size: int = 400,
         gzip_fallback: bool = True,
         excluded_handlers: Union[List, None] = None,
-    ) -> None:
+    ) -> NoReturn:
         """
         Arguments.
 
@@ -64,7 +64,7 @@ class BrotliMiddleware:
         else:
             self.excluded_handlers = []
 
-    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> NoReturn:
         if self._is_handler_excluded(scope):
             return await self.app(scope, receive, send)
         if scope["type"] == "http":
@@ -103,7 +103,7 @@ class BrotliResponder:
         lgwin: int,
         lgblock: int,
         minimum_size: int,
-    ) -> None:  # noqa
+    ) -> NoReturn:  # noqa
         self.app = app
         self.quality = quality
         self.mode = mode
@@ -120,11 +120,11 @@ class BrotliResponder:
 
     async def __call__(
         self, scope: Scope, receive: Receive, send: Send
-    ) -> None:  # noqa
+    ) -> NoReturn:  # noqa
         self.send = send
         await self.app(scope, receive, self.send_with_brotli)
 
-    async def send_with_brotli(self, message: Message) -> None:
+    async def send_with_brotli(self, message: Message) -> NoReturn:
         """Apply compression using brotli."""
         message_type = message["type"]
         if message_type == "http.response.start":
@@ -193,5 +193,5 @@ class BrotliResponder:
         return self.br_file.compress(body)
 
 
-async def unattached_send(message: Message) -> None:
+async def unattached_send(message: Message) -> NoReturn:
     raise RuntimeError("send awaitable not set")  # pragma: no cover


### PR DESCRIPTION
fixes https://github.com/fullonic/brotli-asgi/issues/19

Now is possible to exclude some handlers from being compressed when initializing the brotli middleware.

For example:
```python
app.add_middleware(
    BrotliMiddleware,
    excluded_handlers=["/metrics", "/api/v1/ws", "/api/v1/sse"],
)
```

Note: [Server Side Events](https://github.com/encode/starlette/issues/20#issuecomment-704106436) handlers shouldn't be compressed. 