### PR TITLE
Avoid double encode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ dist
 .mypy_cache
 .pytest_cache
 .vscode
+build

--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ app.add_middleware(
 - _(Optional)_ `minimum_size`: Only compress responses that are bigger than this value in bytes.
 - _(Optional)_ `gzip_fallback`: If `True`, uses gzip encoding if `br` is not in the Accept-Encoding header.
 
+**Notes**:
+
+- It won't apply Brotli compression on responses that already have a Content-Encoding set, to prevent them from being encoded twice.
+- If the GZip fallback is applied, and the response already had a Content-Encoding set, the double-encoding-prevention will only happen if you're using Starlette `>=0.22.0` (see [the PR](https://github.com/encode/starlette/pull/1901)).
+
 ## Performance
 
 To better understand the benefits of Brotli over GZip, see, [Gzip vs. Brotli: Comparing Compression Techniques](https://www.coralnodes.com/gzip-vs-brotli/), where detailed information and benchmarks are provided.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 Brotli==1.0.9
-starlette==0.21.0
+starlette==0.22.0

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,14 @@
 """A compression AGSI middleware using brotli.
 
-Built using starlette under the hood, it can be used as a drop in replacement to
+Built using starlette under the hood, it can be used as a drop-in replacement to
 GZipMiddleware for Starlette or FastAPI.
 """
 
 from setuptools import setup  # type: ignore
 
 extras = {
-    'test_brotli': ['requests==2.23.0', 'mypy==0.770'],
-    'test_brotlipy': ['requests==2.23.0', 'mypy==0.770', 'brotlipy==0.7.0']
+    'test_brotli': ['requests>=2.23.0', 'mypy>=0.770'],
+    'test_brotlipy': ['requests>=2.23.0', 'mypy>=0.770', 'brotlipy>=0.7.0']
 }
 
 setup(


### PR DESCRIPTION
See https://github.com/encode/starlette/pull/1901

I also updated some other files such as gitignore and `setup.py`, and also fixed some typos around.